### PR TITLE
Initialize model drift monitoring toolkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.pytest_cache/
+artifacts/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,77 @@
+# Model Drift Monitor
+
+Model Drift Monitor is a reference implementation of a **model monitoring system** that detects when a machine learning model is no longer performing as expected due to **data drift** or **concept drift**. The project combines statistical tests, performance tracking, and interactive visualisations to support decision making.
+
+## Features
+
+- **Baseline Calculation** – Compute histograms, means, and standard deviations for each feature in the training data and persist the statistics for future comparisons.
+- **Data Drift Detection** – Monitor incoming feature distributions using:
+  - Population Stability Index (PSI)
+  - Kolmogorov–Smirnov (KS) test
+  - Chi-square test for categorical variables
+- **Concept & Performance Monitoring** – Track rolling performance metrics (accuracy, precision, recall, ROC AUC) and flag degradations when thresholds are breached.
+- **Visualisation & Alerts** – Generate Plotly-based drift heatmaps, PSI trends, and performance metric charts. Alerts can be raised when metrics drop below configured thresholds.
+- **Evidently Integration** – Optionally build interactive HTML reports using [Evidently AI](https://www.evidentlyai.com/).
+- **Streamlit Dashboard** – Launch an interactive dashboard (`streamlit run streamlit_app.py`) to explore drift and upload predictions for monitoring.
+
+## Getting Started
+
+### Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+The project depends on `pandas`, `numpy`, `scipy`, `scikit-learn`, `plotly`, `streamlit`, and `evidently` (optional).
+
+### Quick Demo
+
+Run the sample workflow which trains a logistic regression model on synthetic data, generates drifted observations, and exports reports and metrics:
+
+```bash
+python app.py --output artifacts
+```
+
+Generated artefacts include:
+
+- `baseline.json` – persisted baseline statistics
+- `drift_summary.csv` – per-feature drift results
+- `drift_heatmap.html` – interactive Plotly visualisation
+- `metrics.csv` – classification metrics on the drifted dataset
+
+### Streamlit Dashboard
+
+```bash
+streamlit run streamlit_app.py
+```
+
+Use the sidebar controls to simulate different levels of label flips and feature drift. Upload a CSV file containing `y_true`, `y_pred`, and optional `y_proba` columns to evaluate performance metrics in real time.
+
+## Project Structure
+
+```
+Model-Drift-Monitor/
+├── app.py                  # CLI demo for the monitoring workflow
+├── streamlit_app.py        # Streamlit dashboard
+├── src/model_drift_monitor/
+│   ├── __init__.py
+│   ├── baseline.py         # Baseline statistics utilities
+│   ├── drift.py            # PSI, KS, Chi-square drift detection
+│   ├── performance.py      # Performance metrics and alerts
+│   ├── reporting.py        # Evidently AI integration
+│   ├── synthetic.py        # Synthetic dataset generation
+│   └── visualization.py    # Plotly visualisations
+└── tests/                  # Pytest-based unit tests
+```
+
+## Testing
+
+```bash
+pytest
+```
+
+## License
+
+This project is licensed under the terms of the [MIT License](LICENSE).

--- a/app.py
+++ b/app.py
@@ -1,0 +1,85 @@
+"""Command-line interface for running a sample drift monitoring workflow."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import train_test_split
+
+from model_drift_monitor import (
+    compute_baseline_statistics,
+    detect_data_drift,
+    evaluate_classification_performance,
+    plot_drift_heatmap,
+)
+from model_drift_monitor.synthetic import generate_drift_datasets
+
+
+def run_demo(output_dir: Path) -> None:
+    baseline_df, current_df = generate_drift_datasets()
+    feature_columns = [column for column in baseline_df.columns if column != "target"]
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        baseline_df[feature_columns], baseline_df["target"], test_size=0.3, random_state=42
+    )
+    model = LogisticRegression(max_iter=1000)
+    model.fit(X_train, y_train)
+
+    y_pred = model.predict(current_df[feature_columns])
+    y_proba = model.predict_proba(current_df[feature_columns])[:, 1]
+
+    baseline_stats = compute_baseline_statistics(baseline_df[feature_columns])
+    report = detect_data_drift(
+        current_df[feature_columns],
+        baseline_stats,
+        reference_df=baseline_df[feature_columns],
+    )
+    metrics = evaluate_classification_performance(current_df["target"], y_pred, y_proba=y_proba)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    drift_heatmap = plot_drift_heatmap(report)
+    drift_heatmap.write_html(output_dir / "drift_heatmap.html")
+
+    drift_summary = pd.DataFrame(
+        {
+            "feature": list(report.column_results.keys()),
+            "column_type": [result.column_type for result in report.column_results.values()],
+            "psi": [result.psi for result in report.column_results.values()],
+            "ks_pvalue": [result.ks_pvalue for result in report.column_results.values()],
+            "chi2_pvalue": [result.chi2_pvalue for result in report.column_results.values()],
+            "drift_detected": [result.drift_detected for result in report.column_results.values()],
+        }
+    )
+    drift_summary.to_csv(output_dir / "drift_summary.csv", index=False)
+
+    metrics_df = pd.DataFrame(
+        {
+            "accuracy": [metrics.accuracy],
+            "precision": [metrics.precision],
+            "recall": [metrics.recall],
+            "roc_auc": [metrics.roc_auc],
+        }
+    )
+    metrics_df.to_csv(output_dir / "metrics.csv", index=False)
+
+    baseline_stats.to_json(output_dir / "baseline.json")
+
+    print("Drifted columns:", ", ".join(report.drifted_columns) or "None")
+    print("Metrics saved to", output_dir)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the model drift monitor demo")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("artifacts"),
+        help="Directory where reports will be saved.",
+    )
+    args = parser.parse_args()
+    run_demo(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "model-drift-monitor"
+version = "0.1.0"
+description = "Model monitoring system for detecting data and concept drift"
+readme = "README.md"
+authors = [{ name = "Model Drift Team" }]
+license = { text = "MIT" }
+requires-python = ">=3.9"
+dependencies = [
+  "pandas>=1.5",
+  "numpy>=1.23",
+  "scipy>=1.9",
+  "scikit-learn>=1.1",
+  "plotly>=5.0",
+  "streamlit>=1.20",
+  "evidently>=0.3.0"
+]
+
+[project.optional-dependencies]
+test = [
+  "pytest>=7.0",
+]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pandas>=1.5
+numpy>=1.23
+scipy>=1.9
+scikit-learn>=1.1
+plotly>=5.0
+streamlit>=1.20
+evidently>=0.3.0

--- a/src/model_drift_monitor/__init__.py
+++ b/src/model_drift_monitor/__init__.py
@@ -1,0 +1,33 @@
+"""Model Drift Monitor package."""
+from .baseline import BaselineStats, CategoricalBaseline, NumericBaseline, compute_baseline_statistics
+from .drift import ColumnDriftResult, DriftReport, detect_data_drift, population_stability_index
+from .performance import (
+    PerformanceMetrics,
+    ThresholdAlert,
+    check_thresholds,
+    evaluate_classification_performance,
+)
+from .reporting import build_evidently_report, save_report_html
+from .synthetic import generate_drift_datasets
+from .visualization import plot_drift_heatmap, plot_performance_metrics, plot_psi_trend
+
+__all__ = [
+    "BaselineStats",
+    "CategoricalBaseline",
+    "NumericBaseline",
+    "compute_baseline_statistics",
+    "ColumnDriftResult",
+    "DriftReport",
+    "detect_data_drift",
+    "population_stability_index",
+    "PerformanceMetrics",
+    "ThresholdAlert",
+    "check_thresholds",
+    "evaluate_classification_performance",
+    "build_evidently_report",
+    "save_report_html",
+    "generate_drift_datasets",
+    "plot_drift_heatmap",
+    "plot_performance_metrics",
+    "plot_psi_trend",
+]

--- a/src/model_drift_monitor/baseline.py
+++ b/src/model_drift_monitor/baseline.py
@@ -1,0 +1,160 @@
+"""Utilities for computing and persisting baseline statistics for drift monitoring."""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, MutableMapping, Optional
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class NumericBaseline:
+    """Summary statistics for a numeric feature."""
+
+    bins: List[float]
+    probabilities: List[float]
+    mean: float
+    std: float
+    count: int
+
+    @classmethod
+    def from_series(cls, series: pd.Series, bins: int = 20) -> "NumericBaseline":
+        cleaned = series.dropna()
+        count = int(cleaned.shape[0])
+        if count == 0:
+            # Edge case: empty column – generate a degenerate baseline
+            return cls(
+                bins=[0.0, 1.0],
+                probabilities=[1.0],
+                mean=float("nan"),
+                std=float("nan"),
+                count=0,
+            )
+        hist, bin_edges = np.histogram(cleaned.values, bins=bins)
+        total = hist.sum()
+        if total == 0:
+            probabilities = [1.0 / len(hist)] * len(hist)
+        else:
+            probabilities = (hist / total).tolist()
+        return cls(
+            bins=bin_edges.tolist(),
+            probabilities=probabilities,
+            mean=float(cleaned.mean()),
+            std=float(cleaned.std(ddof=0)),
+            count=count,
+        )
+
+
+@dataclass
+class CategoricalBaseline:
+    """Summary statistics for a categorical feature."""
+
+    probabilities: Dict[str, float] = field(default_factory=dict)
+    count: int = 0
+
+    @classmethod
+    def from_series(
+        cls,
+        series: pd.Series,
+        min_frequency: float = 0.01,
+    ) -> "CategoricalBaseline":
+        cleaned = series.dropna().astype(str)
+        count = int(cleaned.shape[0])
+        if count == 0:
+            return cls(probabilities={}, count=0)
+        value_counts = cleaned.value_counts(normalize=True)
+        if min_frequency > 0:
+            major = value_counts[value_counts >= min_frequency]
+            other = value_counts[value_counts < min_frequency].sum()
+            probabilities: MutableMapping[str, float] = major.to_dict()
+            if other > 0:
+                probabilities["__other__"] = float(other)
+        else:
+            probabilities = value_counts.to_dict()
+        return cls(probabilities=dict(probabilities), count=count)
+
+
+@dataclass
+class BaselineStats:
+    """Container for all baseline statistics in a dataset."""
+
+    numeric: Dict[str, NumericBaseline] = field(default_factory=dict)
+    categorical: Dict[str, CategoricalBaseline] = field(default_factory=dict)
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "numeric": {key: asdict(value) for key, value in self.numeric.items()},
+            "categorical": {key: asdict(value) for key, value in self.categorical.items()},
+            "metadata": dict(self.metadata),
+        }
+
+    def to_json(self, path: Path | str) -> None:
+        path = Path(path)
+        path.write_text(json.dumps(self.to_dict(), indent=2))
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, object]) -> "BaselineStats":
+        numeric = {
+            key: NumericBaseline(**value)
+            for key, value in payload.get("numeric", {}).items()
+        }
+        categorical = {
+            key: CategoricalBaseline(**value)
+            for key, value in payload.get("categorical", {}).items()
+        }
+        metadata = dict(payload.get("metadata", {}))
+        return cls(numeric=numeric, categorical=categorical, metadata=metadata)
+
+    @classmethod
+    def from_json(cls, path: Path | str) -> "BaselineStats":
+        payload = json.loads(Path(path).read_text())
+        return cls.from_dict(payload)
+
+
+def compute_baseline_statistics(
+    df: pd.DataFrame,
+    *,
+    numeric_columns: Optional[Iterable[str]] = None,
+    categorical_columns: Optional[Iterable[str]] = None,
+    histogram_bins: int = 20,
+    min_category_frequency: float = 0.01,
+    metadata: Optional[Dict[str, str]] = None,
+) -> BaselineStats:
+    """Compute baseline statistics for all features in a dataframe."""
+
+    metadata = metadata or {}
+
+    if numeric_columns is None:
+        numeric_columns = df.select_dtypes(include=[np.number]).columns.tolist()
+    if categorical_columns is None:
+        categorical_columns = [
+            column
+            for column in df.columns
+            if column not in numeric_columns
+        ]
+
+    stats = BaselineStats(metadata=dict(metadata))
+
+    for column in numeric_columns:
+        stats.numeric[column] = NumericBaseline.from_series(
+            df[column], bins=histogram_bins
+        )
+
+    for column in categorical_columns:
+        stats.categorical[column] = CategoricalBaseline.from_series(
+            df[column], min_frequency=min_category_frequency
+        )
+
+    return stats
+
+
+__all__ = [
+    "BaselineStats",
+    "CategoricalBaseline",
+    "NumericBaseline",
+    "compute_baseline_statistics",
+]

--- a/src/model_drift_monitor/drift.py
+++ b/src/model_drift_monitor/drift.py
@@ -1,0 +1,191 @@
+"""Drift detection utilities including PSI, KS, and Chi-square tests."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+from .baseline import BaselineStats, CategoricalBaseline, NumericBaseline
+
+
+@dataclass
+class ColumnDriftResult:
+    """Stores drift metrics for a single column."""
+
+    column: str
+    column_type: str
+    psi: Optional[float] = None
+    psi_threshold: Optional[float] = None
+    ks_pvalue: Optional[float] = None
+    ks_threshold: Optional[float] = None
+    chi2_pvalue: Optional[float] = None
+    chi2_threshold: Optional[float] = None
+    drift_detected: bool = False
+    unexpected_categories: List[str] = field(default_factory=list)
+
+
+@dataclass
+class DriftReport:
+    """Aggregated results for data drift detection."""
+
+    column_results: Dict[str, ColumnDriftResult] = field(default_factory=dict)
+
+    @property
+    def drifted_columns(self) -> List[str]:
+        return [
+            column
+            for column, result in self.column_results.items()
+            if result.drift_detected
+        ]
+
+
+def population_stability_index(
+    expected_probabilities: Sequence[float],
+    actual_probabilities: Sequence[float],
+    *,
+    epsilon: float = 1e-6,
+) -> float:
+    """Calculate the population stability index (PSI)."""
+
+    expected = np.asarray(expected_probabilities, dtype=float)
+    actual = np.asarray(actual_probabilities, dtype=float)
+    if expected.shape != actual.shape:
+        raise ValueError("Expected and actual probability vectors must match in shape")
+
+    expected = np.where(expected <= 0, epsilon, expected)
+    actual = np.where(actual <= 0, epsilon, actual)
+    psi = np.sum((expected - actual) * np.log(expected / actual))
+    return float(psi)
+
+
+def _numeric_probabilities(series: pd.Series, baseline: NumericBaseline) -> np.ndarray:
+    cleaned = series.dropna()
+    if cleaned.empty:
+        return np.zeros(len(baseline.probabilities))
+    hist, _ = np.histogram(cleaned.values, bins=np.asarray(baseline.bins))
+    total = hist.sum()
+    return hist / total if total else np.zeros_like(hist, dtype=float)
+
+
+def _categorical_probabilities(
+    series: pd.Series, baseline: CategoricalBaseline
+) -> tuple[np.ndarray, List[str]]:
+    cleaned = series.dropna().astype(str)
+    total = cleaned.shape[0]
+    categories = list(baseline.probabilities.keys())
+    counts = dict.fromkeys(categories, 0)
+    others = 0
+    for value, count in cleaned.value_counts().items():
+        if value in counts:
+            counts[value] = count
+        else:
+            others += count
+    if "__other__" in counts:
+        counts["__other__"] += others
+    elif others > 0:
+        categories.append("__other__")
+        counts["__other__"] = others
+    probabilities = np.array(
+        [counts.get(category, 0) / total if total else 0 for category in categories],
+        dtype=float,
+    )
+    return probabilities, categories
+
+
+def detect_data_drift(
+    current_df: pd.DataFrame,
+    baseline: BaselineStats,
+    *,
+    reference_df: Optional[pd.DataFrame] = None,
+    psi_threshold: float = 0.2,
+    ks_pvalue_threshold: float = 0.05,
+    chi2_pvalue_threshold: float = 0.05,
+) -> DriftReport:
+    """Run data drift detection on the current dataset."""
+
+    report = DriftReport()
+
+    for column, numeric_baseline in baseline.numeric.items():
+        current_series = current_df[column]
+        psi_value = population_stability_index(
+            numeric_baseline.probabilities,
+            _numeric_probabilities(current_series, numeric_baseline),
+        )
+        ks_pvalue = None
+        if reference_df is not None and column in reference_df:
+            baseline_series = reference_df[column].dropna()
+            if not baseline_series.empty and not current_series.dropna().empty:
+                ks_stat, ks_pvalue = stats.ks_2samp(
+                    baseline_series.values, current_series.dropna().values
+                )
+        drift_detected = False
+        if psi_value >= psi_threshold:
+            drift_detected = True
+        if ks_pvalue is not None and ks_pvalue < ks_pvalue_threshold:
+            drift_detected = True
+        report.column_results[column] = ColumnDriftResult(
+            column=column,
+            column_type="numeric",
+            psi=psi_value,
+            psi_threshold=psi_threshold,
+            ks_pvalue=ks_pvalue,
+            ks_threshold=ks_pvalue_threshold,
+            drift_detected=drift_detected,
+        )
+
+    for column, categorical_baseline in baseline.categorical.items():
+        current_series = current_df[column]
+        actual_probs, categories = _categorical_probabilities(
+            current_series, categorical_baseline
+        )
+        expected_probs = np.array(
+            [categorical_baseline.probabilities.get(category, 0) for category in categories]
+        )
+        psi_value = population_stability_index(expected_probs, actual_probs)
+
+        current_counts = current_series.dropna().astype(str).value_counts()
+        expected_counts = np.array(
+            [
+                categorical_baseline.probabilities.get(category, 0)
+                * max(current_series.shape[0], 1)
+                for category in categories
+            ]
+        )
+        observed_counts = np.array([current_counts.get(category, 0) for category in categories])
+
+        chi2_pvalue = None
+        if expected_counts.sum() > 0:
+            _, chi2_pvalue = stats.chisquare(f_obs=observed_counts, f_exp=expected_counts)
+
+        unexpected_categories = [
+            category for category in current_counts.index if category not in categories
+        ]
+
+        drift_detected = False
+        if psi_value >= psi_threshold:
+            drift_detected = True
+        if chi2_pvalue is not None and chi2_pvalue < chi2_pvalue_threshold:
+            drift_detected = True
+        report.column_results[column] = ColumnDriftResult(
+            column=column,
+            column_type="categorical",
+            psi=psi_value,
+            psi_threshold=psi_threshold,
+            chi2_pvalue=chi2_pvalue,
+            chi2_threshold=chi2_pvalue_threshold,
+            unexpected_categories=unexpected_categories,
+            drift_detected=drift_detected,
+        )
+
+    return report
+
+
+__all__ = [
+    "ColumnDriftResult",
+    "DriftReport",
+    "detect_data_drift",
+    "population_stability_index",
+]

--- a/src/model_drift_monitor/performance.py
+++ b/src/model_drift_monitor/performance.py
@@ -1,0 +1,96 @@
+"""Performance monitoring utilities for machine learning models."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Optional
+
+import numpy as np
+from sklearn.metrics import accuracy_score, precision_recall_fscore_support, roc_auc_score
+
+
+@dataclass
+class PerformanceMetrics:
+    """Container for common classification metrics."""
+
+    accuracy: Optional[float] = None
+    precision: Optional[float] = None
+    recall: Optional[float] = None
+    f1: Optional[float] = None
+    roc_auc: Optional[float] = None
+    class_balance: Dict[str, float] = field(default_factory=dict)
+    mean_prediction: Optional[float] = None
+
+
+@dataclass
+class ThresholdAlert:
+    """Alerts raised when a metric falls below a threshold."""
+
+    metric: str
+    value: float
+    threshold: float
+
+
+def evaluate_classification_performance(
+    y_true: Iterable[int],
+    y_pred: Iterable[int],
+    *,
+    y_proba: Optional[Iterable[float]] = None,
+    positive_label: int = 1,
+) -> PerformanceMetrics:
+    """Compute core classification metrics."""
+
+    y_true = np.asarray(list(y_true))
+    y_pred = np.asarray(list(y_pred))
+    metrics = PerformanceMetrics()
+
+    if y_true.size == 0:
+        return metrics
+
+    metrics.accuracy = float(accuracy_score(y_true, y_pred))
+
+    precision, recall, f1, _ = precision_recall_fscore_support(
+        y_true, y_pred, average="binary", pos_label=positive_label, zero_division=0
+    )
+    metrics.precision = float(precision)
+    metrics.recall = float(recall)
+    metrics.f1 = float(f1)
+
+    if y_proba is not None:
+        y_proba = np.asarray(list(y_proba))
+        if y_proba.size == y_true.size:
+            metrics.mean_prediction = float(y_proba.mean())
+            try:
+                metrics.roc_auc = float(roc_auc_score(y_true, y_proba))
+            except ValueError:
+                metrics.roc_auc = None
+    else:
+        metrics.mean_prediction = float(np.mean(y_pred))
+
+    unique, counts = np.unique(y_true, return_counts=True)
+    total = counts.sum()
+    metrics.class_balance = {str(label): count / total for label, count in zip(unique, counts)}
+
+    return metrics
+
+
+def check_thresholds(
+    metrics: PerformanceMetrics, thresholds: Dict[str, float]
+) -> Dict[str, ThresholdAlert]:
+    """Return alerts for metrics that violate the provided thresholds."""
+
+    alerts: Dict[str, ThresholdAlert] = {}
+    for metric_name, threshold in thresholds.items():
+        value = getattr(metrics, metric_name, None)
+        if value is not None and value < threshold:
+            alerts[metric_name] = ThresholdAlert(
+                metric=metric_name, value=value, threshold=threshold
+            )
+    return alerts
+
+
+__all__ = [
+    "PerformanceMetrics",
+    "ThresholdAlert",
+    "check_thresholds",
+    "evaluate_classification_performance",
+]

--- a/src/model_drift_monitor/reporting.py
+++ b/src/model_drift_monitor/reporting.py
@@ -1,0 +1,62 @@
+"""Integration with Evidently AI for HTML reporting."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+try:
+    from evidently import ColumnMapping
+    from evidently.metric_preset import ClassificationPreset, DataDriftPreset
+    from evidently.report import Report
+except ImportError:  # pragma: no cover - optional dependency
+    ColumnMapping = object  # type: ignore[assignment]
+    Report = object  # type: ignore[assignment]
+    _EVIDENTLY_AVAILABLE = False
+else:  # pragma: no cover - simply tracks availability
+    _EVIDENTLY_AVAILABLE = True
+
+
+def _ensure_evidently() -> None:
+    if not _EVIDENTLY_AVAILABLE:
+        raise ImportError(
+            "Evidently is required for reporting. Install with `pip install evidently`."
+        )
+
+
+def build_evidently_report(
+    reference_df: pd.DataFrame,
+    current_df: pd.DataFrame,
+    *,
+    target_column: Optional[str] = None,
+    prediction_column: Optional[str] = None,
+    column_mapping: Optional[ColumnMapping] = None,
+) -> Report:
+    """Create an Evidently report for data and concept drift."""
+
+    _ensure_evidently()
+    metrics = [DataDriftPreset()]
+    if target_column is not None and prediction_column is not None:
+        metrics.append(ClassificationPreset())
+
+    report = Report(metrics=metrics)
+    report.run(
+        reference_data=reference_df,
+        current_data=current_df,
+        column_mapping=column_mapping,
+    )
+    return report
+
+
+def save_report_html(report: Report, path: Path | str) -> None:
+    """Persist an Evidently report to an HTML file."""
+
+    _ensure_evidently()
+    Path(path).write_text(report.as_html())
+
+
+__all__ = [
+    "build_evidently_report",
+    "save_report_html",
+]

--- a/src/model_drift_monitor/synthetic.py
+++ b/src/model_drift_monitor/synthetic.py
@@ -1,0 +1,43 @@
+"""Synthetic dataset utilities for demos and tests."""
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.datasets import make_classification
+
+
+def generate_drift_datasets(
+    *,
+    n_samples: int = 5000,
+    n_features: int = 5,
+    drift_strength: float = 0.8,
+    flip_rate: float = 0.2,
+    random_state: int = 42,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Generate baseline and drifted datasets for demonstrations."""
+
+    X, y = make_classification(
+        n_samples=n_samples,
+        n_features=n_features,
+        n_informative=max(2, n_features - 2),
+        n_redundant=0,
+        n_clusters_per_class=1,
+        weights=[0.6, 0.4],
+        random_state=random_state,
+    )
+    feature_names = [f"feature_{i}" for i in range(X.shape[1])]
+    baseline_df = pd.DataFrame(X, columns=feature_names)
+    baseline_df["target"] = y
+
+    rng = np.random.default_rng(random_state + 1)
+    drift_X = X + rng.normal(0, drift_strength, size=X.shape)
+    drift_y = np.where(rng.random(len(y)) < flip_rate, 1 - y, y)
+    current_df = pd.DataFrame(drift_X, columns=feature_names)
+    current_df["target"] = drift_y
+
+    return baseline_df, current_df
+
+
+__all__ = ["generate_drift_datasets"]

--- a/src/model_drift_monitor/visualization.py
+++ b/src/model_drift_monitor/visualization.py
@@ -1,0 +1,64 @@
+"""Visualization helpers for the model drift monitoring system."""
+from __future__ import annotations
+
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+
+from .drift import DriftReport
+
+
+def plot_psi_trend(trend: pd.DataFrame, *, title: str = "PSI Trend") -> go.Figure:
+    """Plot PSI values over time."""
+
+    if "timestamp" not in trend.columns or "psi" not in trend.columns:
+        raise ValueError("The trend dataframe must contain 'timestamp' and 'psi' columns")
+
+    fig = px.line(trend, x="timestamp", y="psi", color="feature", markers=True, title=title)
+    fig.update_layout(yaxis_title="PSI", xaxis_title="Timestamp", hovermode="x unified")
+    return fig
+
+
+def plot_performance_metrics(
+    metrics: pd.DataFrame, *, title: str = "Performance Metrics"
+) -> go.Figure:
+    """Plot rolling model performance metrics."""
+
+    if "timestamp" not in metrics.columns:
+        raise ValueError("Metrics dataframe must include a 'timestamp' column")
+
+    value_columns = [column for column in metrics.columns if column != "timestamp"]
+    fig = px.line(metrics, x="timestamp", y=value_columns, title=title)
+    fig.update_layout(yaxis_title="Metric Value", xaxis_title="Timestamp", hovermode="x unified")
+    return fig
+
+
+def plot_drift_heatmap(report: DriftReport, *, title: str = "Drift Heatmap") -> go.Figure:
+    """Visualize drift status for each feature as a heatmap."""
+
+    if not report.column_results:
+        raise ValueError("Drift report is empty")
+
+    columns = list(report.column_results.keys())
+    status = [1 if report.column_results[column].drift_detected else 0 for column in columns]
+
+    fig = go.Figure(
+        data=go.Heatmap(
+            z=[status],
+            x=columns,
+            y=["drift"],
+            colorscale=[[0, "#1f77b4"], [1, "#d62728"]],
+            showscale=False,
+            text=["Drift" if value else "Stable" for value in status],
+            texttemplate="%{text}",
+        )
+    )
+    fig.update_layout(title=title, xaxis_title="Feature", yaxis=dict(showticklabels=False))
+    return fig
+
+
+__all__ = [
+    "plot_drift_heatmap",
+    "plot_performance_metrics",
+    "plot_psi_trend",
+]

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,77 @@
+"""Streamlit dashboard for the model drift monitor."""
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from model_drift_monitor import (
+    compute_baseline_statistics,
+    detect_data_drift,
+    evaluate_classification_performance,
+    plot_drift_heatmap,
+    plot_performance_metrics,
+    plot_psi_trend,
+)
+from model_drift_monitor.synthetic import generate_drift_datasets
+
+
+st.set_page_config(page_title="Model Drift Monitor", layout="wide")
+st.title("📊 Model Drift Monitor Dashboard")
+
+st.sidebar.header("Data Options")
+flip_rate = st.sidebar.slider("Label flip rate", 0.0, 0.5, 0.2, 0.05)
+drift_strength = st.sidebar.slider("Drift strength", 0.0, 1.5, 0.8, 0.1)
+
+baseline_df, current_df = generate_drift_datasets(flip_rate=flip_rate, drift_strength=drift_strength)
+feature_columns = [column for column in baseline_df.columns if column != "target"]
+
+baseline_stats = compute_baseline_statistics(baseline_df[feature_columns])
+report = detect_data_drift(
+    current_df[feature_columns], baseline_stats, reference_df=baseline_df[feature_columns]
+)
+
+st.subheader("Drift Summary")
+st.write(pd.DataFrame(
+    {
+        "feature": list(report.column_results.keys()),
+        "psi": [result.psi for result in report.column_results.values()],
+        "ks_pvalue": [result.ks_pvalue for result in report.column_results.values()],
+        "chi2_pvalue": [result.chi2_pvalue for result in report.column_results.values()],
+        "drift_detected": [result.drift_detected for result in report.column_results.values()],
+    }
+))
+
+heatmap = plot_drift_heatmap(report)
+st.plotly_chart(heatmap, use_container_width=True)
+
+psi_trend = pd.DataFrame(
+    {
+        "timestamp": pd.date_range(end=pd.Timestamp.utcnow(), periods=len(feature_columns)),
+        "psi": [result.psi for result in report.column_results.values()],
+        "feature": feature_columns,
+    }
+)
+st.plotly_chart(plot_psi_trend(psi_trend), use_container_width=True)
+
+st.subheader("Performance Monitoring")
+st.caption("Upload model predictions to evaluate performance metrics.")
+
+uploaded = st.file_uploader("Upload CSV with columns: y_true, y_pred, y_proba", type="csv")
+if uploaded:
+    df = pd.read_csv(uploaded)
+    metrics = evaluate_classification_performance(
+        df["y_true"], df["y_pred"], y_proba=df.get("y_proba")
+    )
+    metrics_df = pd.DataFrame([
+        {
+            "timestamp": pd.Timestamp.utcnow(),
+            "accuracy": metrics.accuracy,
+            "precision": metrics.precision,
+            "recall": metrics.recall,
+            "roc_auc": metrics.roc_auc,
+        }
+    ])
+    st.plotly_chart(plot_performance_metrics(metrics_df), use_container_width=True)
+    st.json(metrics.__dict__)
+else:
+    st.info("Upload a CSV file to evaluate performance metrics.")

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from model_drift_monitor.baseline import BaselineStats, compute_baseline_statistics
+
+
+def test_compute_baseline_statistics(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        {
+            "num": [1, 2, 3, 4, 5],
+            "cat": ["a", "b", "a", "b", "c"],
+        }
+    )
+
+    stats = compute_baseline_statistics(df)
+    assert "num" in stats.numeric
+    assert "cat" in stats.categorical
+    assert stats.numeric["num"].mean == df["num"].mean()
+
+    output = tmp_path / "baseline.json"
+    stats.to_json(output)
+    loaded = BaselineStats.from_json(output)
+    assert loaded.numeric["num"].count == stats.numeric["num"].count
+    assert loaded.categorical["cat"].probabilities == stats.categorical["cat"].probabilities

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from model_drift_monitor.baseline import compute_baseline_statistics
+from model_drift_monitor.drift import detect_data_drift
+
+
+def test_detect_data_drift_numeric_shift() -> None:
+    rng = np.random.default_rng(42)
+    baseline = pd.DataFrame({"feature": rng.normal(0, 1, size=1000)})
+    current = pd.DataFrame({"feature": rng.normal(2, 1, size=1000)})
+
+    baseline_stats = compute_baseline_statistics(baseline)
+    report = detect_data_drift(current, baseline_stats, reference_df=baseline)
+
+    result = report.column_results["feature"]
+    assert result.psi is not None and result.psi > 0.2
+    assert result.drift_detected
+
+
+def test_detect_data_drift_categorical_shift() -> None:
+    baseline = pd.DataFrame({"feature": ["a"] * 80 + ["b"] * 20})
+    current = pd.DataFrame({"feature": ["a"] * 30 + ["b"] * 70})
+
+    baseline_stats = compute_baseline_statistics(baseline)
+    report = detect_data_drift(current, baseline_stats)
+
+    result = report.column_results["feature"]
+    assert result.psi is not None and result.psi > 0.2
+    assert result.drift_detected

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import numpy as np
+
+from model_drift_monitor.performance import (
+    PerformanceMetrics,
+    check_thresholds,
+    evaluate_classification_performance,
+)
+
+
+def test_evaluate_classification_performance() -> None:
+    y_true = np.array([0, 0, 1, 1])
+    y_pred = np.array([0, 1, 1, 1])
+    y_proba = np.array([0.1, 0.6, 0.8, 0.9])
+
+    metrics = evaluate_classification_performance(y_true, y_pred, y_proba=y_proba)
+    assert isinstance(metrics, PerformanceMetrics)
+    assert metrics.accuracy == 0.75
+    assert metrics.mean_prediction is not None
+    assert metrics.roc_auc is not None
+
+
+def test_check_thresholds_flags_alerts() -> None:
+    metrics = PerformanceMetrics(accuracy=0.6, precision=0.5, recall=0.4)
+    thresholds = {"accuracy": 0.7, "recall": 0.5}
+
+    alerts = check_thresholds(metrics, thresholds)
+    assert set(alerts.keys()) == {"accuracy", "recall"}


### PR DESCRIPTION
## Summary
- bootstrap a Python package for computing baseline statistics, detecting drift, and tracking model performance
- add demo CLI and Streamlit dashboard for visualising drift, performance metrics, and generating reports
- provide Evidently AI integration utilities plus pytest coverage for baseline, drift, and performance helpers

## Testing
- pytest *(fails: missing pandas/numpy in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dafa23e4988325931afb8a6b7e827a